### PR TITLE
Report errors when using inotify:watch/1,2

### DIFF
--- a/src/inotify.app.src
+++ b/src/inotify.app.src
@@ -1,5 +1,5 @@
 {application, inotify, [{description, "Linux file alternation monitor."},
-                        {vsn, "0.4.0"},
+                        {vsn, "0.4.1"},
 			{registered, [inotify_server, inotify_evt]},
                         {applications, [kernel,
                                         stdlib]},

--- a/src/inotify.erl
+++ b/src/inotify.erl
@@ -98,7 +98,7 @@ watch(File) ->
                    reference().
 watch(File, Mask) ->
     EventTag = make_ref(),
-    inotify_server:watch(File, EventTag, Mask),
+    ok = inotify_server:watch(File, EventTag, Mask),
     EventTag.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
Client code needs to know if inotify:watch/1,2 succeeds or fails (for instance, the file does not exist). Without this guarantee the API is unusable, since clients cannot tell if they can rely on it to detect changes to the filesystem.

I created a branch 0.4.x I chose to use exceptions to report this failure. Perhaps a nicer approach would be to report an {ok, Ref} | {error, Error} tuples for the master branch?
