### PR TITLE
Added missing <string.h> include in erl_comm.c

### DIFF
--- a/c_src/erl_comm.c
+++ b/c_src/erl_comm.c
@@ -1,6 +1,7 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 #include <ei.h>
 #include "erl_comm.h"
 


### PR DESCRIPTION
memset in function read_cmd is provided by string.h. Newer version of GCC generate error on missing includes